### PR TITLE
Merge Schedule: use PAT instead of Github token 

### DIFF
--- a/.github/workflows/merge-schedule.yml
+++ b/.github/workflows/merge-schedule.yml
@@ -26,4 +26,4 @@ jobs:
           # `automerge-fail`.
           automerge_fail_label: "merge-schedule-failed"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.LOA_WORKFLOW_TOKEN }}


### PR DESCRIPTION
to ensure workflows on main trigger

/schedule 2025-08-11T11:00:00.000Z