### PR TITLE
Fix typo in cop field from 'RISVA' to 'RIVSA'

### DIFF
--- a/data/EDMM/EDUU/ost.toml
+++ b/data/EDMM/EDUU/ost.toml
@@ -411,7 +411,7 @@ from_sector = "ed/MEI"
 to_sector = "ed/SPE1"
 
 [[agreements]]
-cop = "RISVA"
+cop = "RIVSA"
 level = 310
 vertical = true
 adep = ["EDDE"]


### PR DESCRIPTION
Reported in https://github.com/VATGER-Nav/edmm-package/issues/81